### PR TITLE
Update Chatwoot API endpoint in HTTP GET request

### DIFF
--- a/Whatsapp/Helper.cs
+++ b/Whatsapp/Helper.cs
@@ -129,7 +129,7 @@ namespace SamparkBot {
 
     private static async Task<ChatwootModels.Conversation> GetOrCreateChatwootConversationByPhone(Sender sender) {
       using var client = new HttpClient();
-      using var request = new HttpRequestMessage(new HttpMethod("GET"), $"{aggregatorBaseUrl}contacts/search?q={sender.Phone?.Replace("+", "")}");
+      using var request = new HttpRequestMessage(new HttpMethod("GET"), $"{aggregatorBaseUrl}api/v1/accounts/1/contacts/search?q={sender.Phone?.Replace("+", "")}");
       AddChatwootHeaders(request);
 
       var response = await client.SendAsync(request);


### PR DESCRIPTION
Modified the URL in the GetOrCreateChatwootConversationByPhone method to include the new API endpoint structure: "api/v1/accounts/1/contacts/search". This change reflects an update to the Chatwoot service's API versioning or account structure.