### PR TITLE
Simplify URL in GetOrCreateChatwootConversationByPhone

### DIFF
--- a/Whatsapp/Helper.cs
+++ b/Whatsapp/Helper.cs
@@ -129,7 +129,7 @@ namespace SamparkBot {
 
     private static async Task<ChatwootModels.Conversation> GetOrCreateChatwootConversationByPhone(Sender sender) {
       using var client = new HttpClient();
-      using var request = new HttpRequestMessage(new HttpMethod("GET"), $"{aggregatorBaseUrl}api/v1/accounts/1/contacts/search?q={sender.Phone?.Replace("+", "")}");
+      using var request = new HttpRequestMessage(new HttpMethod("GET"), $"{aggregatorBaseUrl}contacts/search?q={sender.Phone?.Replace("+", "")}");
       AddChatwootHeaders(request);
 
       var response = await client.SendAsync(request);


### PR DESCRIPTION
The URL used to search for contacts by phone number has been simplified by removing the `api/v1/accounts/1/` path segment. This change likely reflects an update in the API endpoint structure or a simplification of the request URL.